### PR TITLE
Add logic to resolve http call non-OK status

### DIFF
--- a/providers/alibaba.go
+++ b/providers/alibaba.go
@@ -54,5 +54,9 @@ func IdentifyAlibabaViaMetadataServer(detected chan<- string, log logrus.FieldLo
 		if strings.HasPrefix(string(body), "ecs.") {
 			detected <- defaults.Alibaba
 		}
+	} else {
+		log.Errorf("Something happened during the request with status %s", resp.Status)
+		detected <- defaults.Unknown
+		return
 	}
 }

--- a/providers/aws.go
+++ b/providers/aws.go
@@ -71,6 +71,10 @@ func IdentifyAmazonViaMetadataServer(detected chan<- string, log logrus.FieldLog
 			detected <- defaults.Amazon
 			return
 		}
+	} else {
+		log.Errorf("Something happened during the request with status %s", resp.Status)
+		detected <- defaults.Unknown
+		return
 	}
 
 }

--- a/providers/azure.go
+++ b/providers/azure.go
@@ -46,5 +46,9 @@ func IdentifyAzureViaMetadataServer(detected chan<- string, log logrus.FieldLogg
 	}
 	if resp.StatusCode == http.StatusOK {
 		detected <- defaults.Azure
+	} else {
+		log.Errorf("Something happened during the request with status %s", resp.Status)
+		detected <- defaults.Unknown
+		return
 	}
 }

--- a/providers/digitalocean.go
+++ b/providers/digitalocean.go
@@ -67,5 +67,9 @@ func IdentifyDigitalOceanViaMetadataServer(detected chan<- string, log logrus.Fi
 		if r.DropletID > 0 {
 			detected <- defaults.DigitalOcean
 		}
+	} else {
+		log.Errorf("Something happened during the request with status %s", resp.Status)
+		detected <- defaults.Unknown
+		return
 	}
 }

--- a/providers/google.go
+++ b/providers/google.go
@@ -46,5 +46,9 @@ func IdentifyGoogleViaMetadataServer(detected chan<- string, log logrus.FieldLog
 	}
 	if resp.StatusCode == http.StatusOK {
 		detected <- defaults.Google
+	} else {
+		log.Errorf("Something happened during the request with status %s", resp.Status)
+		detected <- defaults.Unknown
+		return
 	}
 }

--- a/providers/oracle.go
+++ b/providers/oracle.go
@@ -67,5 +67,9 @@ func IdentifyOracleViaMetadataServer(detected chan<- string, log logrus.FieldLog
 		if strings.Contains(r.OkeTM, "oke") {
 			detected <- defaults.Oracle
 		}
+	} else {
+		log.Errorf("Something happened during the request with status %s", resp.Status)
+		detected <- defaults.Unknown
+		return
 	}
 }


### PR DESCRIPTION
Current logic cannot support to identify the provider if the http call response status is not OK(200)